### PR TITLE
Add integration example for Microsoft SQL server

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -9,6 +9,7 @@ start_docker "3" "3" "" ""
 
 r2dbc_client_artifactory=$(pwd)/r2dbc-client-artifactory
 r2dbc_h2_artifactory=$(pwd)/r2dbc-h2-artifactory
+r2dbc_mssql_artifactory=$(pwd)/r2dbc-mssql-artifactory
 r2dbc_postgresql_artifactory=$(pwd)/r2dbc-postgresql-artifactory
 r2dbc_spi_artifactory=$(pwd)/r2dbc-spi-artifactory
 
@@ -18,5 +19,6 @@ cd r2dbc-client
 ./mvnw deploy \
     -DaltDeploymentRepository=distribution::default::file://${r2dbc_client_artifactory} \
     -Dr2dbcH2Artifactory=file://${r2dbc_h2_artifactory} \
+    -Dr2dbcMssqlArtifactory=file://${r2dbc_mssql_artifactory} \
     -Dr2dbcPostgresqlArtifactory=file://${r2dbc_postgresql_artifactory} \
     -Dr2dbcSpiArtifactory=file://${r2dbc_spi_artifactory}

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -9,6 +9,7 @@ image_resource:
 inputs:
 - name: r2dbc-client
 - name: r2dbc-h2-artifactory
+- name: r2dbc-mssql-artifactory
 - name: r2dbc-postgresql-artifactory
 - name: r2dbc-spi-artifactory
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,13 @@
         <junit.version>5.3.1</junit.version>
         <logback.version>1.2.3</logback.version>
         <postgresql.version>42.2.5</postgresql.version>
+        <mssql-jdbc.version>7.0.0.jre8</mssql-jdbc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-spi.version>1.0.0.BUILD-SNAPSHOT</r2dbc-spi.version>
         <r2dbc-postgresql.version>1.0.0.BUILD-SNAPSHOT</r2dbc-postgresql.version>
         <r2dbc-h2.version>1.0.0.BUILD-SNAPSHOT</r2dbc-h2.version>
+        <r2dbc-mssql.version>1.0.0.BUILD-SNAPSHOT</r2dbc-mssql.version>
         <reactor.version>Californium-SR2</reactor.version>
         <spring-boot.version>2.1.0.RELEASE</spring-boot.version>
         <testcontainers.version>1.9.1</testcontainers.version>
@@ -137,9 +139,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-mssql</artifactId>
+            <version>${r2dbc-mssql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>${mssql-jdbc.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -151,6 +165,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -275,6 +294,23 @@
                 <repository>
                     <id>r2dbc-postgresql-artifactory</id>
                     <url>${r2dbcPostgresqlArtifactory}</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>r2dbc-mssql-artifactory</id>
+            <activation>
+                <property>
+                    <name>r2dbcMssqlArtifactory</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>r2dbc-mssql-artifactory</id>
+                    <url>${r2dbcMssqlArtifactory}</url>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>

--- a/src/test/java/io/r2dbc/client/MssqlExample.java
+++ b/src/test/java/io/r2dbc/client/MssqlExample.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.client;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.r2dbc.mssql.MssqlConnectionConfiguration;
+import io.r2dbc.mssql.MssqlConnectionFactory;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.MSSQLServerContainer;
+import reactor.util.annotation.Nullable;
+
+import java.io.IOException;
+
+final class MssqlExample implements Example<String> {
+
+    @RegisterExtension
+    static final MssqlServerExtension SERVER = new MssqlServerExtension();
+
+    private final MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+        .host(SERVER.getHost())
+        .port(SERVER.getPort())
+        .password(SERVER.getPassword())
+        .username(SERVER.getUsername())
+        .build();
+
+    private final R2dbc r2dbc = new R2dbc(new MssqlConnectionFactory(this.configuration));
+
+    @Override
+    public JdbcOperations getJdbcOperations() {
+        JdbcOperations jdbcOperations = SERVER.getJdbcOperations();
+
+        if (jdbcOperations == null) {
+            throw new IllegalStateException("JdbcOperations not yet initialized");
+        }
+
+        return jdbcOperations;
+    }
+
+    @Override
+    @Disabled("Batch-PreparedStatements not yet supported")
+    public void prepareStatement() {
+    }
+
+    @Override
+    public String getIdentifier(int index) {
+        return String.format("P%d", index);
+    }
+
+    @Override
+    public String getPlaceholder(int index) {
+        return String.format("@P%d", index);
+    }
+
+    @Override
+    public R2dbc getR2dbc() {
+        return this.r2dbc;
+    }
+
+    private static final class MssqlServerExtension implements BeforeAllCallback, AfterAllCallback {
+
+        private final MSSQLServerContainer<?> container = new MSSQLServerContainer<>();
+
+        private HikariDataSource dataSource;
+
+        private JdbcOperations jdbcOperations;
+
+        @Override
+        public void afterAll(ExtensionContext context) {
+            this.dataSource.close();
+            this.container.stop();
+        }
+
+        @Override
+        public void beforeAll(ExtensionContext context) throws IOException {
+            this.container.start();
+
+            this.dataSource = DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .url(this.container.getJdbcUrl())
+                .username(this.container.getUsername())
+                .password(this.container.getPassword())
+                .build();
+
+            this.dataSource.setMaximumPoolSize(1);
+
+            this.jdbcOperations = new JdbcTemplate(this.dataSource);
+        }
+
+        String getHost() {
+            return this.container.getContainerIpAddress();
+        }
+
+        @Nullable
+        JdbcOperations getJdbcOperations() {
+            return this.jdbcOperations;
+        }
+
+        String getPassword() {
+            return this.container.getPassword();
+        }
+
+        int getPort() {
+            return this.container.getMappedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT);
+        }
+
+        String getUsername() {
+            return this.container.getUsername();
+        }
+
+    }
+}

--- a/src/test/resources/container-license-acceptance.txt
+++ b/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+microsoft/mssql-server-linux:2017-CU6

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -25,6 +25,7 @@
 
     <logger name="io.r2dbc.client"     level="INFO"/>
     <logger name="io.r2dbc.postgresql" level="INFO"/>
+    <logger name="io.r2dbc.mssql"      level="INFO"/>
     <logger name="org.testcontainers"  level="INFO"/>
     <logger name="reactor.netty"       level="WARN"/>
     <logger name="stream"              level="INFO"/>


### PR DESCRIPTION
Add example integration for `r2dbc-mssql`. Prepared batch statements are not yet supported hence this particular example is disabled for now.