### PR TITLE
Update README: replace outdated 'execute' with 'mapResult' in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ r2dbc.inTransaction(handle ->
 
     .thenMany(r2dbc.inTransaction(handle ->
         handle.select("SELECT value FROM test")
-            .execute(result -> result.map((row, rowMetadata) -> row.get("value", Integer.class)))))
+            .mapResult(result -> result.map((row, rowMetadata) -> row.get("value", Integer.class)))))
 
     .subscribe(System.out::println);
 ```


### PR DESCRIPTION
- `.select(..).execute(..)` is no longer applicable. `mapResult` now contains `execute` within it.