### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This project is an exploration of what a Java API for relational database access
 
 [jd]: http://jdbi.org
 [pr]: https://projectreactor.io
-[rs]: http://www.reactive-streams.org
+[rs]: https://www.reactive-streams.org
 
 ## Examples
 A quick example of configuration and execution would look like:


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://jdbi.org (200) with 1 occurrences could not be migrated:  
   ([https](https://jdbi.org) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.reactive-streams.org with 1 occurrences migrated to:  
  https://www.reactive-streams.org ([https](https://www.reactive-streams.org) result 200).