### PR TITLE
Add mysql example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-h2.version>${project.version}</r2dbc-h2.version>
         <r2dbc-mssql.version>${project.version}</r2dbc-mssql.version>
-        <r2dbc-mysql.version>0.9.36</r2dbc-mysql.version>
+        <r2dbc-mysql.version>0.9.38</r2dbc-mysql.version>
         <mysql.version>8.0.12</mysql.version>
         <r2dbc-postgresql.version>${project.version}</r2dbc-postgresql.version>
         <r2dbc-spi.version>${project.version}</r2dbc-spi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-h2.version>${project.version}</r2dbc-h2.version>
         <r2dbc-mssql.version>${project.version}</r2dbc-mssql.version>
+        <r2dbc-mysql.version>0.9.36</r2dbc-mysql.version>
+        <mysql.version>8.0.12</mysql.version>
         <r2dbc-postgresql.version>${project.version}</r2dbc-postgresql.version>
         <r2dbc-spi.version>${project.version}</r2dbc-spi.version>
         <reactor.version>Californium-SR3</reactor.version>
@@ -145,6 +147,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.jasync-sql</groupId>
+            <artifactId>jasync-r2dbc-mysql</artifactId>
+            <version>${r2dbc-mysql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
@@ -165,6 +179,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -272,6 +291,10 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
         </repository>
     </repositories>
 

--- a/src/test/java/io/r2dbc/client/MysqlExample.java
+++ b/src/test/java/io/r2dbc/client/MysqlExample.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.client;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.r2dbc.spi.ConnectionFactories;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.MySQLContainer;
+import reactor.util.annotation.Nullable;
+
+import static com.github.jasync.r2dbc.mysql.MysqlConnectionFactoryProvider.MYSQL_DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.builder;
+
+final class MysqlExample implements Example<String> {
+
+    @RegisterExtension
+    static final MysqlServerExtension SERVER = new MysqlServerExtension();
+
+    private final R2dbc r2dbc = new R2dbc(ConnectionFactories.get(builder()
+        .option(DRIVER, MYSQL_DRIVER)
+        .option(HOST, SERVER.getHost())
+        .option(PORT, SERVER.getPort())
+        .option(PASSWORD, SERVER.getPassword())
+        .option(USER, SERVER.getUsername())
+        .build()));
+
+
+    @Override
+    public String getIdentifier(int index) {
+        return String.format("P%d", index);
+    }
+
+    @Override
+    public JdbcOperations getJdbcOperations() {
+        JdbcOperations jdbcOperations = SERVER.getJdbcOperations();
+
+        if (jdbcOperations == null) {
+            throw new IllegalStateException("JdbcOperations not yet initialized");
+        }
+
+        return jdbcOperations;
+    }
+
+    @Override
+    public String getPlaceholder(int index) {
+        return String.format("@P%d", index);
+    }
+
+    @Override
+    public R2dbc getR2dbc() {
+        return this.r2dbc;
+    }
+
+    private static final class MysqlServerExtension implements BeforeAllCallback, AfterAllCallback {
+
+        private final MySQLContainer<?> container = new MySQLContainer<>("mysql:5.7");
+
+        private HikariDataSource dataSource;
+
+        private JdbcOperations jdbcOperations;
+
+        @Override
+        public void afterAll(ExtensionContext context) {
+            this.dataSource.close();
+            this.container.stop();
+        }
+
+        @Override
+        public void beforeAll(ExtensionContext context) {
+            this.container.start();
+
+            this.dataSource = DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .url(this.container.getJdbcUrl())
+                .username(this.container.getUsername())
+                .password(this.container.getPassword())
+                .build();
+
+            this.dataSource.setMaximumPoolSize(1);
+
+            this.jdbcOperations = new JdbcTemplate(this.dataSource);
+        }
+
+        String getHost() {
+            return this.container.getContainerIpAddress();
+        }
+
+        @Nullable
+        JdbcOperations getJdbcOperations() {
+            return this.jdbcOperations;
+        }
+
+        String getPassword() {
+            return this.container.getPassword();
+        }
+
+        int getPort() {
+            return this.container.getFirstMappedPort();
+        }
+
+        String getUsername() {
+            return this.container.getUsername();
+        }
+
+    }
+}

--- a/src/test/java/io/r2dbc/client/MysqlExample.java
+++ b/src/test/java/io/r2dbc/client/MysqlExample.java
@@ -25,11 +25,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.MySQLContainer;
 import reactor.util.annotation.Nullable;
 
 import static com.github.jasync.r2dbc.mysql.MysqlConnectionFactoryProvider.MYSQL_DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
@@ -43,12 +43,13 @@ final class MysqlExample implements Example<String> {
     static final MysqlServerExtension SERVER = new MysqlServerExtension();
 
     private final R2dbc r2dbc = new R2dbc(ConnectionFactories.get(builder()
-        .option(DRIVER, MYSQL_DRIVER)
-        .option(HOST, SERVER.getHost())
-        .option(PORT, SERVER.getPort())
-        .option(PASSWORD, SERVER.getPassword())
-        .option(USER, SERVER.getUsername())
-        .build()));
+            .option(DRIVER, MYSQL_DRIVER)
+            .option(HOST, SERVER.getHost())
+            .option(PORT, SERVER.getPort())
+            .option(PASSWORD, SERVER.getPassword())
+            .option(USER, SERVER.getUsername())
+            .option(DATABASE, SERVER.getDatabase())
+            .build()));
 
 
     @Override
@@ -96,11 +97,11 @@ final class MysqlExample implements Example<String> {
             this.container.start();
 
             this.dataSource = DataSourceBuilder.create()
-                .type(HikariDataSource.class)
-                .url(this.container.getJdbcUrl())
-                .username(this.container.getUsername())
-                .password(this.container.getPassword())
-                .build();
+                    .type(HikariDataSource.class)
+                    .url(this.container.getJdbcUrl())
+                    .username(this.container.getUsername())
+                    .password(this.container.getPassword())
+                    .build();
 
             this.dataSource.setMaximumPoolSize(1);
 
@@ -128,5 +129,8 @@ final class MysqlExample implements Example<String> {
             return this.container.getUsername();
         }
 
+        String getDatabase() {
+            return this.container.getDatabaseName();
+        }
     }
 }

--- a/src/test/java/io/r2dbc/client/MysqlExample.java
+++ b/src/test/java/io/r2dbc/client/MysqlExample.java
@@ -54,7 +54,7 @@ final class MysqlExample implements Example<String> {
 
     @Override
     public String getIdentifier(int index) {
-        return String.format("P%d", index);
+        return String.valueOf(index);
     }
 
     @Override
@@ -70,7 +70,7 @@ final class MysqlExample implements Example<String> {
 
     @Override
     public String getPlaceholder(int index) {
-        return String.format("@P%d", index);
+        return "?";
     }
 
     @Override

--- a/src/test/java/io/r2dbc/client/MysqlExample.java
+++ b/src/test/java/io/r2dbc/client/MysqlExample.java
@@ -18,6 +18,8 @@ package io.r2dbc.client;
 
 import com.zaxxer.hikari.HikariDataSource;
 import io.r2dbc.spi.ConnectionFactories;
+import org.junit.Ignore;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -132,5 +134,10 @@ final class MysqlExample implements Example<String> {
         String getDatabase() {
             return this.container.getDatabaseName();
         }
+    }
+
+    @Test
+    @Ignore("compound statements are not supported by the driver")
+    @Override public void compoundStatement() {
     }
 }

--- a/src/test/java/io/r2dbc/client/MysqlExample.java
+++ b/src/test/java/io/r2dbc/client/MysqlExample.java
@@ -138,6 +138,7 @@ final class MysqlExample implements Example<String> {
 
     @Test
     @Ignore("compound statements are not supported by the driver")
-    @Override public void compoundStatement() {
+    @Override
+    public void compoundStatement() {
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -26,6 +26,7 @@
     <logger name="io.r2dbc.client"     level="INFO"/>
     <logger name="io.r2dbc.postgresql" level="INFO"/>
     <logger name="io.r2dbc.mssql"      level="INFO"/>
+    <logger name="com.github.jasync"   level="INFO"/>
     <logger name="org.testcontainers"  level="INFO"/>
     <logger name="reactor.netty"       level="WARN"/>
     <logger name="stream"              level="INFO"/>


### PR DESCRIPTION
The example is still not working because of the following error:
`java.lang.IllegalStateException: Unable to create a ConnectionFactory for 'ConnectionFactoryOptions{options={user=test, driver=mysql, host=localhost, password=REDACTED, port=32782}}'. Available drivers: [ postgresql, h2, mssql ]
`

Probably need to include changes from mysql branch of spring-data-r2dbc:
https://github.com/spring-projects/spring-data-r2dbc/compare/mysql