### PR TITLE
Upgrade to MySQL 0.8.0.RC2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-h2.version>${project.version}</r2dbc-h2.version>
         <r2dbc-mssql.version>${project.version}</r2dbc-mssql.version>
-        <r2dbc-mysql.version>0.3.0.BUILD-SNAPSHOT</r2dbc-mysql.version>
+        <r2dbc-mysql.version>${project.version}</r2dbc-mysql.version>
         <r2dbc-pool.version>${project.version}</r2dbc-pool.version>
         <r2dbc-postgresql.version>${project.version}</r2dbc-postgresql.version>
         <r2dbc-spi.version>${project.version}</r2dbc-spi.version>


### PR DESCRIPTION
The `r2dbc-mysql` should do also the releases to keep in sync with R2DBC versioning for now unless major bug. So we can upgrade `r2dbc-mysql.version` to `project.version`.
